### PR TITLE
Added support for byte arrays when parsing c source

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.4.8.{build}
+version: 0.5.0.{build}
 
 environment:
   PYTHONUNBUFFERED: 1

--- a/pycstruct/cparser.py
+++ b/pycstruct/cparser.py
@@ -272,8 +272,15 @@ class _CastXmlParser():
         if 'float' in typename or 'double' in typename:
             pycstruct_type_name = 'float'
         elif length > 1 and 'char' in typename:
-            # char of length > 1 are considered UTF-8 data
-            pycstruct_type_name = 'utf-'
+            if 'unsigned' in typename:
+                # unsigned char of length > 1 are considered uint8 array
+                pycstruct_type_name = 'uint'
+            elif 'signed' in typename:
+                # signed char of length > 1 are considered int8 array
+                pycstruct_type_name = 'int'
+            else:
+                # char of length > 1 are considered UTF-8 data (string)
+                pycstruct_type_name = 'utf-'
         elif 'unsigned' in typename:
             pycstruct_type_name = 'uint'
         else:
@@ -424,6 +431,12 @@ def parse_file(input_files, byteorder = 'native',
 
        Alignment will automatically be detected and configured for the pycstruct
        instances.
+
+       Note that following pycstruct types will be used for char arrays:
+
+       - 'unsigned char []' = uint8 array
+       - 'signed char []' = int8 array
+       - 'char []' = utf-8 data (string) 
        
        :param input_files: Source file name or a list of file names.
        :type input_files: str or list
@@ -493,6 +506,12 @@ def parse_str(str, byteorder = 'native',
 
        Alignment will automatically be detected and configured for the pycstruct
        instances.
+
+       Note that following pycstruct types will be used for char arrays:
+
+       - 'unsigned char []' = uint8 array
+       - 'signed char []' = int8 array
+       - 'char []' = utf-8 data (string) 
        
        :param str: A string of C source code.
        :type str: str

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
       long_description = ""
 
 setup(name='pycstruct',
-      version='0.4.8',
+      version='0.5.0',
       description='Binary data handling in Python using dictionaries',
       long_description=long_description,
        long_description_content_type="text/markdown",

--- a/tests/special_cases.h
+++ b/tests/special_cases.h
@@ -29,3 +29,9 @@ enum signed_enum {
     semem3 = 2,
     semem_fill = 0xFFFFFFFF
 };
+
+struct different_char_arrays {
+    char char_array[10];
+    unsigned char unsigned_char_array[10];
+    signed char signed_char_array[10];
+};

--- a/tests/special_cases.xml
+++ b/tests/special_cases.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <CastXML format="1.1.5">
-  <Namespace id="_1" name="::" members="_2 _3 _4 _5 _6 _7 _8 _9 _10 _11 _12 _13"/>
-  <Typedef id="_2" name="__int128_t" type="_14" context="_1" location="f0:0" file="f0" line="0"/>
-  <Typedef id="_3" name="__uint128_t" type="_15" context="_1" location="f0:0" file="f0" line="0"/>
-  <Typedef id="_4" name="__NSConstantString" type="_16" context="_1" location="f0:0" file="f0" line="0"/>
-  <Typedef id="_5" name="__builtin_ms_va_list" type="_17" context="_1" location="f0:0" file="f0" line="0"/>
-  <Typedef id="_6" name="__builtin_va_list" type="_18" context="_1" location="f0:0" file="f0" line="0"/>
-  <Struct id="_7" name="name_conflict" context="_1" location="f1:1" file="f1" line="1" members="_19" size="32" align="32"/>
-  <Union id="_8" name="" context="_1" location="f1:5" file="f1" line="5" members="_20 _21" size="32" align="32"/>
-  <Typedef id="_9" name="name_conflict" type="_22" context="_1" location="f1:8" file="f1" line="8"/>
-  <Struct id="_10" name="non_supported_member" context="_1" location="f1:10" file="f1" line="10" members="_23" size="3200" align="32"/>
-  <Struct id="_11" name="with_volatile" context="_1" location="f1:14" file="f1" line="14" members="_24 _25" size="96" align="32"/>
+  <Namespace id="_1" name="::" members="_2 _3 _4 _5 _6 _7 _8 _9 _10 _11 _12 _13 _14"/>
+  <Typedef id="_2" name="__int128_t" type="_15" context="_1" location="f0:0" file="f0" line="0"/>
+  <Typedef id="_3" name="__uint128_t" type="_16" context="_1" location="f0:0" file="f0" line="0"/>
+  <Typedef id="_4" name="__NSConstantString" type="_17" context="_1" location="f0:0" file="f0" line="0"/>
+  <Typedef id="_5" name="__builtin_ms_va_list" type="_18" context="_1" location="f0:0" file="f0" line="0"/>
+  <Typedef id="_6" name="__builtin_va_list" type="_19" context="_1" location="f0:0" file="f0" line="0"/>
+  <Struct id="_7" name="name_conflict" context="_1" location="f1:1" file="f1" line="1" members="_20" size="32" align="32"/>
+  <Union id="_8" name="" context="_1" location="f1:5" file="f1" line="5" members="_21 _22" size="32" align="32"/>
+  <Typedef id="_9" name="name_conflict" type="_23" context="_1" location="f1:8" file="f1" line="8"/>
+  <Struct id="_10" name="non_supported_member" context="_1" location="f1:10" file="f1" line="10" members="_24" size="3200" align="32"/>
+  <Struct id="_11" name="with_volatile" context="_1" location="f1:14" file="f1" line="14" members="_25 _26" size="96" align="32"/>
   <Enumeration id="_12" name="filled_enum" context="_1" location="f1:19" file="f1" line="19" size="32" align="32">
     <EnumValue name="emem1" init="0"/>
     <EnumValue name="emem2" init="1"/>
@@ -23,41 +23,50 @@
     <EnumValue name="semem3" init="2"/>
     <EnumValue name="semem_fill" init="4294967295"/>
   </Enumeration>
-  <FundamentalType id="_14" name="__int128" size="128" align="128"/>
-  <FundamentalType id="_15" name="unsigned __int128" size="128" align="128"/>
-  <Struct id="_16" name="__NSConstantString_tag" context="_1" location="f0:0" file="f0" line="0" members="_26 _27 _28 _29" size="256" align="64"/>
-  <PointerType id="_17" type="_30" size="64" align="64"/>
-  <ArrayType id="_18" min="0" max="0" type="_31"/>
-  <Field id="_19" name="member" type="_32" context="_7" access="public" location="f1:2" file="f1" line="2" offset="0"/>
-  <Field id="_20" name="member1" type="_32" context="_8" access="public" location="f1:6" file="f1" line="6" offset="0"/>
-  <Field id="_21" name="member2" type="_32" context="_8" access="public" location="f1:7" file="f1" line="7" offset="0"/>
-  <ElaboratedType id="_22" type="_8"/>
-  <Field id="_23" name="matrix" type="_33" context="_10" access="public" location="f1:11" file="f1" line="11" offset="0"/>
-  <Field id="_24" name="volatile_member" type="_32v" context="_11" access="public" location="f1:15" file="f1" line="15" offset="0"/>
-  <Field id="_25" name="volatile_array" type="_34" context="_11" access="public" location="f1:16" file="f1" line="16" offset="32"/>
-  <Field id="_26" name="isa" type="_35" context="_16" access="public" offset="0"/>
-  <Field id="_27" name="flags" type="_32" context="_16" access="public" offset="64"/>
-  <Field id="_28" name="str" type="_36" context="_16" access="public" offset="128"/>
-  <Field id="_29" name="length" type="_37" context="_16" access="public" offset="192"/>
-  <Struct id="_31" name="__va_list_tag" context="_1" location="f0:0" file="f0" line="0" members="_38 _39 _40 _41" size="192" align="64"/>
-  <FundamentalType id="_32" name="int" size="32" align="32"/>
-  <CvQualifiedType id="_32v" type="_32" volatile="1"/>
-  <ArrayType id="_33" min="0" max="9" type="_42"/>
-  <ArrayType id="_34" min="0" max="1" type="_32v"/>
-  <PointerType id="_35" type="_32c" size="64" align="64"/>
-  <CvQualifiedType id="_32c" type="_32" const="1"/>
-  <PointerType id="_36" type="_30c" size="64" align="64"/>
-  <CvQualifiedType id="_30c" type="_30" const="1"/>
-  <FundamentalType id="_37" name="long int" size="64" align="64"/>
-  <Field id="_38" name="gp_offset" type="_43" context="_31" access="public" offset="0"/>
-  <Field id="_39" name="fp_offset" type="_43" context="_31" access="public" offset="32"/>
-  <Field id="_40" name="overflow_arg_area" type="_44" context="_31" access="public" offset="64"/>
-  <Field id="_41" name="reg_save_area" type="_44" context="_31" access="public" offset="128"/>
-  <ArrayType id="_42" min="0" max="9" type="_32"/>
-  <FundamentalType id="_43" name="unsigned int" size="32" align="32"/>
-  <PointerType id="_44" type="_45" size="64" align="64"/>
-  <FundamentalType id="_30" name="char" size="8" align="8"/>
-  <FundamentalType id="_45" name="void" size="0" align="8"/>
+  <Struct id="_14" name="different_char_arrays" context="_1" location="f1:33" file="f1" line="33" members="_27 _28 _29" size="240" align="8"/>
+  <FundamentalType id="_15" name="__int128" size="128" align="128"/>
+  <FundamentalType id="_16" name="unsigned __int128" size="128" align="128"/>
+  <Struct id="_17" name="__NSConstantString_tag" context="_1" location="f0:0" file="f0" line="0" members="_30 _31 _32 _33" size="256" align="64"/>
+  <PointerType id="_18" type="_34" size="64" align="64"/>
+  <ArrayType id="_19" min="0" max="0" type="_35"/>
+  <Field id="_20" name="member" type="_36" context="_7" access="public" location="f1:2" file="f1" line="2" offset="0"/>
+  <Field id="_21" name="member1" type="_36" context="_8" access="public" location="f1:6" file="f1" line="6" offset="0"/>
+  <Field id="_22" name="member2" type="_36" context="_8" access="public" location="f1:7" file="f1" line="7" offset="0"/>
+  <ElaboratedType id="_23" type="_8"/>
+  <Field id="_24" name="matrix" type="_37" context="_10" access="public" location="f1:11" file="f1" line="11" offset="0"/>
+  <Field id="_25" name="volatile_member" type="_36v" context="_11" access="public" location="f1:15" file="f1" line="15" offset="0"/>
+  <Field id="_26" name="volatile_array" type="_38" context="_11" access="public" location="f1:16" file="f1" line="16" offset="32"/>
+  <Field id="_27" name="char_array" type="_39" context="_14" access="public" location="f1:34" file="f1" line="34" offset="0"/>
+  <Field id="_28" name="unsigned_char_array" type="_40" context="_14" access="public" location="f1:35" file="f1" line="35" offset="80"/>
+  <Field id="_29" name="signed_char_array" type="_41" context="_14" access="public" location="f1:36" file="f1" line="36" offset="160"/>
+  <Field id="_30" name="isa" type="_42" context="_17" access="public" offset="0"/>
+  <Field id="_31" name="flags" type="_36" context="_17" access="public" offset="64"/>
+  <Field id="_32" name="str" type="_43" context="_17" access="public" offset="128"/>
+  <Field id="_33" name="length" type="_44" context="_17" access="public" offset="192"/>
+  <Struct id="_35" name="__va_list_tag" context="_1" location="f0:0" file="f0" line="0" members="_45 _46 _47 _48" size="192" align="64"/>
+  <FundamentalType id="_36" name="int" size="32" align="32"/>
+  <CvQualifiedType id="_36v" type="_36" volatile="1"/>
+  <ArrayType id="_37" min="0" max="9" type="_49"/>
+  <ArrayType id="_38" min="0" max="1" type="_36v"/>
+  <ArrayType id="_39" min="0" max="9" type="_34"/>
+  <FundamentalType id="_34" name="char" size="8" align="8"/>
+  <ArrayType id="_40" min="0" max="9" type="_50"/>
+  <ArrayType id="_41" min="0" max="9" type="_51"/>
+  <PointerType id="_42" type="_36c" size="64" align="64"/>
+  <CvQualifiedType id="_36c" type="_36" const="1"/>
+  <PointerType id="_43" type="_34c" size="64" align="64"/>
+  <CvQualifiedType id="_34c" type="_34" const="1"/>
+  <FundamentalType id="_44" name="long int" size="64" align="64"/>
+  <Field id="_45" name="gp_offset" type="_52" context="_35" access="public" offset="0"/>
+  <Field id="_46" name="fp_offset" type="_52" context="_35" access="public" offset="32"/>
+  <Field id="_47" name="overflow_arg_area" type="_53" context="_35" access="public" offset="64"/>
+  <Field id="_48" name="reg_save_area" type="_53" context="_35" access="public" offset="128"/>
+  <ArrayType id="_49" min="0" max="9" type="_36"/>
+  <FundamentalType id="_50" name="unsigned char" size="8" align="8"/>
+  <FundamentalType id="_51" name="signed char" size="8" align="8"/>
+  <FundamentalType id="_52" name="unsigned int" size="32" align="32"/>
+  <PointerType id="_53" type="_54" size="64" align="64"/>
+  <FundamentalType id="_54" name="void" size="0" align="8"/>
   <File id="f0" name="&lt;builtin&gt;"/>
   <File id="f1" name="special_cases.h"/>
 </CastXML>

--- a/tests/test_cparser.py
+++ b/tests/test_cparser.py
@@ -96,6 +96,18 @@ class TestCParser(unittest.TestCase):
     self.assertTrue('with_volatile' in instance)
     self.assertTrue('filled_enum' in instance)
     self.assertTrue('signed_enum' in instance)
+    self.assertTrue('different_char_arrays' in instance)
+
+    # Check types of different_char_arrays members.
+    # Since type cannot be read out from StructDef
+    # for individual members we use the __str__ 
+    # representation
+    char_array_str = str(instance['different_char_arrays'])
+    rows = char_array_str.splitlines()
+    self.assertEqual(rows[1].split()[1], 'utf-8')
+    self.assertEqual(rows[2].split()[1], 'uint8')
+    self.assertEqual(rows[3].split()[1], 'int8')
+
 
 
   #@unittest.skipIf(True, 'temporary skipped')


### PR DESCRIPTION
Previously all type of char arrays where converted to UTF-8
strings. Now following pycstruct types will be used:

- 'unsigned char []' = uint8 array
- 'signed char []' = int8 array
- 'char []' = utf-8 data (string)