### PR TITLE
Compute numpy dtype

### DIFF
--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -100,7 +100,7 @@ class _BaseDef:
 
     def dtype(self):
         """Returns the numpy dtype of this definition"""
-        raise NotImplementedError("dtype not implemented for %s" % type(self))
+        raise Exception("dtype not implemented for %s" % type(self))
 
 
 ###############################################################################

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -241,6 +241,7 @@ class StructDef(_BaseDef):
         self.__pad_count = 0
         self.__fields = collections.OrderedDict()
         self.__fields_same_level = collections.OrderedDict()
+        self.__dtype = None
 
         # Add end padding of 0 size
         self.__pad_byte = BasicTypeDef("uint8", default_byteorder)
@@ -327,6 +328,9 @@ class StructDef(_BaseDef):
         :type same_level: bool, optional
 
         """
+        # Invalidate the dtype cache
+        self.__dtype = None
+
         # pylint: disable=too-many-branches
         # Sanity checks
         if length < 1:
@@ -673,6 +677,9 @@ class StructDef(_BaseDef):
         if name not in self.__fields:
             raise Exception("Element {} does not exist".format(name))
 
+        # Invalidate the dtype cache
+        self.__dtype = None
+
         keys = list(self.__fields)
         if not to_criteria:
             keys.reverse()
@@ -739,6 +746,9 @@ class StructDef(_BaseDef):
         return 1
 
     def dtype(self):
+        if self.__dtype is not None:
+            return self.__dtype
+
         names = []
         formats = []
         offsets = []

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -19,21 +19,21 @@ import sys
 
 # Basic Types
 _TYPE = {
-    "int8": {"format": "b", "bytes": 1},
-    "uint8": {"format": "B", "bytes": 1},
+    "int8": {"format": "b", "bytes": 1, "dtype": "i1"},
+    "uint8": {"format": "B", "bytes": 1, "dtype": "u1"},
     "bool8": {"format": "B", "bytes": 1},
-    "int16": {"format": "h", "bytes": 2},
-    "uint16": {"format": "H", "bytes": 2},
+    "int16": {"format": "h", "bytes": 2, "dtype": "i2"},
+    "uint16": {"format": "H", "bytes": 2, "dtype": "u2"},
     "bool16": {"format": "H", "bytes": 2},
-    "float16": {"format": "e", "bytes": 2},
-    "int32": {"format": "i", "bytes": 4},
-    "uint32": {"format": "I", "bytes": 4},
+    "float16": {"format": "e", "bytes": 2, "dtype": "f2"},
+    "int32": {"format": "i", "bytes": 4, "dtype": "i4"},
+    "uint32": {"format": "I", "bytes": 4, "dtype": "u4"},
     "bool32": {"format": "I", "bytes": 4},
-    "float32": {"format": "f", "bytes": 4},
-    "int64": {"format": "q", "bytes": 8},
-    "uint64": {"format": "Q", "bytes": 8},
+    "float32": {"format": "f", "bytes": 4, "dtype": "f4"},
+    "int64": {"format": "q", "bytes": 8, "dtype": "i8"},
+    "uint64": {"format": "Q", "bytes": 8, "dtype": "u8"},
     "bool64": {"format": "Q", "bytes": 8},
-    "float64": {"format": "d", "bytes": 8},
+    "float64": {"format": "d", "bytes": 8, "dtype": "f8"},
 }
 
 _BYTEORDER = {
@@ -98,6 +98,10 @@ class _BaseDef:
     def _type_name(self):
         raise NotImplementedError
 
+    def dtype(self):
+        """Returns the numpy dtype of this definition"""
+        raise NotImplementedError("dtype not implemented for %s" % type(self))
+
 
 ###############################################################################
 # BasicTypeDef Class
@@ -141,6 +145,15 @@ class BasicTypeDef(_BaseDef):
 
     def _type_name(self):
         return self.type
+
+    def dtype(self):
+        dtype = _TYPE[self.type].get("dtype")
+        if dtype is None:
+            raise NotImplementedError(
+                'Basic type "%s" is not implemented as dtype' % self.type
+            )
+        byteorder = _BYTEORDER[self.byteorder]["format"]
+        return byteorder + dtype
 
 
 ###############################################################################
@@ -189,6 +202,9 @@ class StringDef(_BaseDef):
 
     def _type_name(self):
         return "utf-8"
+
+    def dtype(self):
+        return ("S", self.length)
 
 
 ###############################################################################
@@ -721,6 +737,36 @@ class StructDef(_BaseDef):
         if name in self.__fields:
             return self.__fields[name]["length"]
         return 1
+
+    def dtype(self):
+        names = []
+        formats = []
+        offsets = []
+
+        for name in self._element_names():
+            if name.startswith("__pad"):
+                continue
+            if name not in self.__fields:
+                continue
+            length = self.__fields[name]["length"]
+            offset = self.__fields[name]["offset"]
+            datatype = self.__fields[name]["type"]
+            if length > 1:
+                dtype = (datatype.dtype(), length)
+            else:
+                dtype = datatype.dtype()
+            names.append(name)
+            formats.append(dtype)
+            offsets.append(offset)
+
+        dtype_def = {
+            "names": names,
+            "formats": formats,
+            "offsets": offsets,
+            "itemsize": self.size(),
+        }
+        self.__dtype = dtype_def
+        return dtype_def
 
 
 ###############################################################################

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -746,6 +746,24 @@ class StructDef(_BaseDef):
         return 1
 
     def dtype(self):
+        """Returns the dtype of this structure as defined by numpy.
+
+        This allows to use the pycstruct modelization together with numpy
+        to read C structures from buffers.
+
+        .. code-block::
+
+            color_t = StructDef()
+            color_t.add("uint8", "r")
+            color_t.add("uint8", "g")
+            color_t.add("uint8", "b")
+            color_t.add("uint8", "a")
+            raw = b"\x01\x02\x03\x00"
+            color = numpy.frombuffer(raw, dtype=color_t.dtype())
+
+        :return: a python dict representing a numpy dtype
+        :rtype: dict
+        """
         if self.__dtype is not None:
             return self.__dtype
 

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -328,9 +328,6 @@ class StructDef(_BaseDef):
         :type same_level: bool, optional
 
         """
-        # Invalidate the dtype cache
-        self.__dtype = None
-
         # pylint: disable=too-many-branches
         # Sanity checks
         if length < 1:
@@ -345,6 +342,9 @@ class StructDef(_BaseDef):
             raise Exception("same_level not allowed in combination with length > 1")
         if same_level and not isinstance(datatype, BitfieldDef):
             raise Exception("same_level only allowed in combination with BitfieldDef")
+
+        # Invalidate the dtype cache
+        self.__dtype = None
 
         # Create objects when necessary
         if datatype == "utf-8":

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -121,3 +121,21 @@ class TestDtype(unittest.TestCase):
         assert r1["uint32"] == r2["uint32"]
         numpy.testing.assert_array_equal(r1["ubyte"], r2["ubyte"])
         assert r1["rgba"]["b"] == r2["rgba"]["b"]
+
+    def test_unsupported_bitfields(self):
+        bitfield_t = pycstruct.BitfieldDef()
+        bitfield_t.add("one_bit")
+        foo_t = pycstruct.StructDef()
+        foo_t.add(bitfield_t, "thing")
+
+        with self.assertRaisesRegex(Exception, "BitfieldDef"):
+            foo_t.dtype()
+
+    def test_unsupported_enum(self):
+        enum_t = pycstruct.EnumDef()
+        enum_t.add("first")
+        foo_t = pycstruct.StructDef()
+        foo_t.add(enum_t, "thing")
+
+        with self.assertRaisesRegex(Exception, "EnumDef"):
+            foo_t.dtype()

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,123 @@
+import unittest
+from pycstruct import pycstruct
+
+try:
+    import numpy
+except:
+    numpy = None
+
+
+class TestDtype(unittest.TestCase):
+    def setUp(self):
+        if numpy is None:
+            self.skipTest("numpy is not installed")
+
+    def deserialize(self, type_t, data):
+        r1 = type_t.deserialize(data)
+        r2 = numpy.frombuffer(data, dtype=type_t.dtype(), count=1)[0]
+        return r1, r2
+
+    def test_uint32(self):
+        type_t = pycstruct.BasicTypeDef("uint32", "little")
+        data = b"\x01\x02\x03\x04"
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1 == r2
+
+    def test_float32(self):
+        type_t = pycstruct.BasicTypeDef("float32", "little")
+        data = b"\x01\x02\x03\x04"
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1 == r2
+
+    def test_rgba_struct(self):
+        data = b"\x01\x02\x03\x00"
+        type_t = pycstruct.StructDef()
+        type_t.add("uint8", "r")
+        type_t.add("uint8", "g")
+        type_t.add("uint8", "b")
+        type_t.add("uint8", "a")
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1["r"] == r2["r"]
+        assert r1["g"] == r2["g"]
+        assert r1["b"] == r2["b"]
+        assert r1["a"] == r2["a"]
+
+    def test_string_in_struct(self):
+        data = b"\x64\x64\x64\x64"
+        type_t = pycstruct.StructDef()
+        type_t.add("utf-8", "text", 4)
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1["text"] == r2["text"].decode("ascii")
+
+    def test_array_in_struct(self):
+        data = b"\x01\x02\x03\x00"
+        type_t = pycstruct.StructDef()
+        type_t.add("uint8", "data", 4)
+        r1, r2 = self.deserialize(type_t, data)
+        numpy.testing.assert_array_equal(r1["data"], r2["data"])
+
+    def test_struct_in_struct(self):
+        data = b"\x01\x02\x03\x00\x11\x12\x13\x10"
+        rgba_t = pycstruct.StructDef()
+        rgba_t.add("uint8", "r")
+        rgba_t.add("uint8", "g")
+        rgba_t.add("uint8", "b")
+        rgba_t.add("uint8", "a")
+
+        type_t = pycstruct.StructDef()
+        type_t.add(rgba_t, "color1", 1)
+        type_t.add(rgba_t, "color2", 1)
+
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1["color1"]["r"] == r2["color1"]["r"]
+        assert r1["color1"]["g"] == r2["color1"]["g"]
+        assert r1["color2"]["r"] == r2["color2"]["r"]
+        assert r1["color2"]["g"] == r2["color2"]["g"]
+
+    def test_array_of_struct_in_struct(self):
+        data = b"\x01\x02\x03\x00\x11\x12\x13\x10"
+        rgba_t = pycstruct.StructDef()
+        rgba_t.add("uint8", "r")
+        rgba_t.add("uint8", "g")
+        rgba_t.add("uint8", "b")
+        rgba_t.add("uint8", "a")
+
+        type_t = pycstruct.StructDef()
+        type_t.add(rgba_t, "colors", 2)
+
+        r1, r2 = self.deserialize(type_t, data)
+        assert r1["colors"][0]["r"] == r2["colors"][0]["r"]
+        assert r1["colors"][0]["g"] == r2["colors"][0]["g"]
+        assert r1["colors"][1]["r"] == r2["colors"][1]["r"]
+        assert r1["colors"][1]["g"] == r2["colors"][1]["g"]
+
+    def test_union(self):
+        data = b"\x01\x02\x03\x00"
+        any_uint_t = pycstruct.StructDef(union=True)
+        any_uint_t.add("uint8", "u1")
+        any_uint_t.add("uint16", "u2")
+        any_uint_t.add("uint32", "u4")
+
+        r1, r2 = self.deserialize(any_uint_t, data)
+        assert r1["u1"] == r2["u1"]
+        assert r1["u2"] == r2["u2"]
+        assert r1["u4"] == r2["u4"]
+
+    def test_union_of_structs(self):
+        data = b"\x01\x02\x03\x00"
+
+        rgba_t = pycstruct.StructDef()
+        rgba_t.add("uint8", "r")
+        rgba_t.add("uint8", "g")
+        rgba_t.add("uint8", "b")
+        rgba_t.add("uint8", "a")
+
+        color_t = pycstruct.StructDef(union=True)
+        color_t.add("uint32", "uint32")
+        color_t.add(rgba_t, "rgba")
+        color_t.add("uint8", "ubyte", length=4)
+
+        r1, r2 = self.deserialize(color_t, data)
+        assert r1["uint32"] == r2["uint32"]
+        numpy.testing.assert_array_equal(r1["ubyte"], r2["ubyte"])
+        assert r1["rgba"]["b"] == r2["rgba"]["b"]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps = coverage==4.5.4
        coveralls
        black
        pylint
+       numpy
 
 passenv = COVERALLS_REPO_TOKEN
 


### PR DESCRIPTION
This PR introduce a `dtype` method for definition classes.

This can be used with numpy to parse a bytes structure.

This can be used the following way:
```
import pycstruct
import numpy

rgba_t = pycstruct.StructDef()
rgba_t.add("uint8", "r")
rgba_t.add("uint8", "g")
rgba_t.add("uint8", "b")
rgba_t.add("uint8", "a")

data = b'\x01\x02\x03\x00'
rgba = numpy.frombuffer(data, dtype=type_t.dtype(), count=1)[0]
assert rgba["r"] == 1
```
This also can be deserialized the following way to read the fields by argument.
```
data = b'\x01\x02\x03\x00'
rgba = numpy.frombuffer(data, dtype=type_t.dtype(), count=1)[0] 
rgba = numpy.rec.array(rgba) 
assert rgba.r == 1
```


There is some limitations:
- No bitfields
- <s>No unions</s> (fixed)
- No string decoding (everything is bytes)
- <s>The result have to be handled in different way sometimes</s> (fixed)
