### PR TITLE
Update gitignore with coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ doc/build
 htmlcov
 build
 dist
+/.*
+*.py,cover


### PR DESCRIPTION
The PR add few other files in gitignore.

- `*.py,cover` are generated by the python voverage module when it is used with the `annotate` report
- Filtering files from the root starting with `.` is convenient (it matches a lot of IDE cache files)