### PR TITLE
Support bool8 with numpy

### DIFF
--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -21,7 +21,7 @@ import sys
 _TYPE = {
     "int8": {"format": "b", "bytes": 1, "dtype": "i1"},
     "uint8": {"format": "B", "bytes": 1, "dtype": "u1"},
-    "bool8": {"format": "B", "bytes": 1},
+    "bool8": {"format": "B", "bytes": 1, "dtype": "b1"},
     "int16": {"format": "h", "bytes": 2, "dtype": "i2"},
     "uint16": {"format": "H", "bytes": 2, "dtype": "u2"},
     "bool16": {"format": "H", "bytes": 2},

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -132,9 +132,19 @@ class TestDtype(unittest.TestCase):
         type_t.add(bitfield_t, "bf", same_level=True)
         assert len(type_t.dtype()) != 0
 
+    def test_basictype(self):
+        testdefs = [("bool8", "=b1"), ("int8", "=i1")]
+        for testdef in testdefs:
+            typedef, expected = testdef
+            with self.subTest(typedef=typedef, expected=expected):
+                type_t = pycstruct.StructDef()
+                type_t.add(typedef, "a")
+                d = type_t.dtype()
+                self.assertEqual(d["formats"][0], expected)
+
     def test_unsupported_basictype(self):
         type_t = pycstruct.StructDef()
-        type_t.add("bool8", "a")
+        type_t.add("bool16", "a")
 
         with self.assertRaisesRegex(Exception, "Basic type"):
             type_t.dtype()


### PR DESCRIPTION
Hi,

Here is an implementation for the bool8 in numpy.

Other bool types are still not supported.