### PR TITLE
Update type hint in add method of StructDef

### DIFF
--- a/pycstruct/cparser.py
+++ b/pycstruct/cparser.py
@@ -66,7 +66,7 @@ def _run_castxml(
 
 
 def _get_hash(list_of_strings):
-    """ Get a reproducible short name of a list of strings """
+    """Get a reproducible short name of a list of strings"""
     long_string = "".join(list_of_strings)
     sha256 = hashlib.sha256(long_string.encode())
     hexdigest = sha256.hexdigest()
@@ -74,7 +74,7 @@ def _get_hash(list_of_strings):
 
 
 def _listify(list_or_str):
-    """ If list_or_str is a string it will be put in a list """
+    """If list_or_str is a string it will be put in a list"""
     if isinstance(list_or_str, str):
         list_or_str = [list_or_str]
     return list_or_str
@@ -241,7 +241,7 @@ class _CastXmlParser:
         return bitfield
 
     def _set_common_meta(self, xml_input, dict_output):
-        """ Set common metadata available for all types """
+        """Set common metadata available for all types"""
         typeid = xml_input.attrib["id"]
         name = self._get_attrib(xml_input, "name", "")
         if name == "":
@@ -253,7 +253,7 @@ class _CastXmlParser:
         dict_output["supported"] = True
 
     def _set_struct_union_members(self, xml_input, dict_output):
-        """ Set members - common for struct and unions """
+        """Set members - common for struct and unions"""
         dict_output["members"] = []
         fields = self._get_fields(xml_input)
         while len(fields) > 0:
@@ -322,7 +322,7 @@ class _CastXmlParser:
         return elem
 
     def _get_typedef_name(self, type_id):
-        """ Find out the typedef name of a type which do not have a name """
+        """Find out the typedef name of a type which do not have a name"""
 
         # First check if there is a connected ElaboratedType element
         try:
@@ -342,7 +342,7 @@ class _CastXmlParser:
         return name
 
     def _fundamental_type_to_pycstruct_type(self, elem, is_array):
-        """ Map the fundamental type to pycstruct type """
+        """Map the fundamental type to pycstruct type"""
         # pylint: disable=no-self-use
         typename = elem.attrib["name"]
         typesize = elem.attrib["size"]
@@ -367,7 +367,7 @@ class _CastXmlParser:
         return "{0}{1}".format(pycstruct_type_name, typesize)
 
     def _get_basic_type_element(self, type_id):
-        """ Finds the basic type element possible hidden behind TypeDef's or ElaboratedType's """
+        """Finds the basic type element possible hidden behind TypeDef's or ElaboratedType's"""
         elem = self._get_elem_with_id(type_id)
         while elem.tag == "Typedef" or elem.tag == "ElaboratedType":
             elem = self._get_elem_with_id(elem.attrib["type"])

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -155,7 +155,7 @@ class BasicTypeDef(_BaseDef):
         self.format = _TYPE[datatype]["format"]
 
     def serialize(self, data, buffer=None, offset=0):
-        """ Data needs to be an integer, floating point or boolean value """
+        """Data needs to be an integer, floating point or boolean value"""
         if buffer is None:
             assert offset == 0, "When buffer is None, offset have to be unset"
             buffer = bytearray(self.size())
@@ -167,7 +167,7 @@ class BasicTypeDef(_BaseDef):
         return buffer
 
     def deserialize(self, buffer, offset=0):
-        """ Result is an integer, floating point or boolean value """
+        """Result is an integer, floating point or boolean value"""
         dataformat = _BYTEORDER[self.byteorder]["format"] + self.format
         value = struct.unpack_from(dataformat, buffer, offset)[0]
 
@@ -209,7 +209,7 @@ class StringDef(_BaseDef):
         self.length = length
 
     def serialize(self, data, buffer=None, offset=0):
-        """ Data needs to be a string """
+        """Data needs to be a string"""
         if buffer is None:
             assert offset == 0, "When buffer is None, offset have to be unset"
             buffer = bytearray(self.size())
@@ -232,7 +232,7 @@ class StringDef(_BaseDef):
         return buffer
 
     def deserialize(self, buffer, offset=0):
-        """ Result is a string """
+        """Result is a string"""
         size = self.size()
         # Find null termination
         index = buffer.find(0, offset, offset + size)
@@ -1209,7 +1209,7 @@ class BitfieldDef(_BaseDef):
         """
         # pylint: disable=too-many-arguments,no-self-use
         # Validate size according to nbr_of_bits
-        max_value = 2 ** nbr_of_bits - 1
+        max_value = 2**nbr_of_bits - 1
         min_value = 0
         if signed:
             max_value = 2 ** (nbr_of_bits - 1) - 1

--- a/pycstruct/pycstruct.py
+++ b/pycstruct/pycstruct.py
@@ -508,7 +508,7 @@ class StructDef(_BaseDef):
            +------------+---------------+--------------------------------------+
 
         :param datatype: Element data type. See above.
-        :type datatype: str
+        :type datatype: str | _BaseDef
         :param name: Name of element. Needs to be unique.
         :type name: str
         :param length: Number of elements. If > 1 this is an array/list of


### PR DESCRIPTION
Since StructDef.add can accept instances of other subclasses of _BaseDef for the datatype, this type hint doesn't cover all possible cases, which annoys my IDE and type checker.